### PR TITLE
chore: set up pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!--- These comments are hidden when you submit the pull request, --->
+<!--- so you do not need to remove them. --->
+
+<!--- Before opening a pull request, go over all the following points: --->
+<!--- * I have read the contributor guide (CONTRIBUTING.md) --->
+<!--- * My code follows the code style of this project --->
+<!--- * I added tests to cover my changes --->
+<!--- * If needed, I updated the documentation --->
+<!--- * If needed, I added translations if they are needed --->
+<!--- * If needed, I added migration files and checked for potential conflicts --->
+
+<!--- This project only accepts pull requests related to open issues. --->
+<!--- If suggesting a new feature or change, please discuss it in an issue first. --->
+<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. --->
+
+<!--- Please provide a general summary of your changes in the title of the pull request --->
+
+## Description
+<!--- Describe your changes in detail --->
+
+<!--- Please link to a related issue here --->
+Resolves #ISSUE_NUMBER
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? --->
+
+## How has this been tested?
+<!--- Please describe in detail how you tested your changes. --->
+<!--- Include details of your testing environment, and the tests you ran to --->
+<!--- see how your change affects other areas of the code, etc. --->
+
+## Screenshots (if appropriate)
+
+<!--- This pull request template is adapted from: --->
+<!--- https://github.com/TalAter/open-source-templates (MIT License). --->
+<!--- https://github.com/dec0dOS/amazing-github-template (MIT License). --->


### PR DESCRIPTION
Fixes #3

I copied the version from the `dev-2.2.0` branch of the main rdmo repo:
https://github.com/rdmorganiser/rdmo/blob/dev-2.2.0/.github/PULL_REQUEST_TEMPLATE.md